### PR TITLE
Add semver support to API client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   },
   "require": {
     "guzzlehttp/guzzle": "^6.2",
-    "cascade-energy/php-service-discovery-client": "^1.0.0"
+    "cascade-energy/php-service-discovery-client": "^1.0.0",
+    "composer/semver": "^1.4"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "760f11d8c0ccbb4987932b69708aa43d",
-    "content-hash": "a584622b5e5148413cbd4c9831623615",
+    "hash": "936a6fc07c43ba80961be47e69559195",
+    "content-hash": "c72bd33be9bca4455d4b9d99a21c5443",
     "packages": [
         {
             "name": "cascade-energy/php-service-discovery-client",
@@ -39,6 +39,68 @@
             ],
             "description": "Base interfaces for PHP service discovery libraries",
             "time": "2016-05-09 18:43:05"
+        },
+        {
+            "name": "composer/semver",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "84c47f3d8901440403217afc120683c7385aecb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/84c47f3d8901440403217afc120683c7385aecb8",
+                "reference": "84c47f3d8901440403217afc120683c7385aecb8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-03-30 13:16:03"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/src/Consul/ConsulApi.php
+++ b/src/Consul/ConsulApi.php
@@ -20,6 +20,11 @@ class ConsulApi implements ServiceDiscoveryClientInterface
         $this->consulUri = $consulUri;
     }
 
+    /**
+     * @param $serviceName The name of the service to locate
+     * @param null $version A semver version constraint, or null if no version constraint is required
+     * @return bool|string The IP address and port of a suitable service instance, or false if no services were found
+     */
     public function getServiceAddress($serviceName, $version = null)
     {
         $url = "{$this->consulUri}/v1/health/service/$serviceName?passing";

--- a/tests/Consul/ConsulApiTest.php
+++ b/tests/Consul/ConsulApiTest.php
@@ -45,19 +45,91 @@ class ConsulApiTest extends \PHPUnit_Framework_TestCase
         )->evaluate($address);
     }
 
-    public function testItShouldPassThroughAVersionIdIfOneIsProvided()
+    public function testItShouldFilterServicesBySemverConstraints()
     {
         $response = $this->getMock('Psr\Http\Message\ResponseInterface');
-        $resultList = [['Service' => ['Address' => 'alpha', 'Port' => 42]]];
+        $resultList = $this->getServiceListWithVersions();
         $response->expects($this->once())->method('getBody')->willReturn(json_encode($resultList));
 
         $this->httpClient
             ->expects($this->once())
             ->method('get')
-            ->with('http://foo.bar.baz/v1/health/service/qux?passing&tag=bagel.burrito')
+            ->with('http://foo.bar.baz/v1/health/service/qux?passing')
             ->willReturn($response);
 
-        $this->consulApi->getServiceAddress('qux', 'bagel.burrito');
+        $result = $this->consulApi->getServiceAddress('qux', '^1.0.0');
+
+        $this->assertEquals('alpha:42', $result);
+    }
+
+    public function testItShouldApplyAllVersionTagsIfAServiceHasMoreThanOne()
+    {
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $resultList = $this->getServiceListWithVersions();
+        $response->expects($this->exactly(2))->method('getBody')->willReturn(json_encode($resultList));
+
+        $this->httpClient
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->with('http://foo.bar.baz/v1/health/service/qux?passing')
+            ->willReturn($response);
+
+        $result = $this->consulApi->getServiceAddress('qux', '^3.0.0');
+        $this->assertEquals('gamma:62', $result);
+
+        $result = $this->consulApi->getServiceAddress('qux', '^2-2-0');
+        $this->assertEquals('gamma:62', $result);
+    }
+
+    public function testItShouldReturnFalseIfNoServiceSatisfiesTheSemverConstraint()
+    {
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $resultList = $this->getServiceListWithVersions();
+        $response->expects($this->once())->method('getBody')->willReturn(json_encode($resultList));
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('http://foo.bar.baz/v1/health/service/qux?passing')
+            ->willReturn($response);
+
+        $result = $this->consulApi->getServiceAddress('qux', '=1-1-0');
+        $this->assertFalse($result);
+    }
+
+    public function testHyphensAndDotsShouldBeInterchangableInVersionNumbers()
+    {
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $resultList = $this->getServiceListWithVersions();
+        $response->expects($this->once())->method('getBody')->willReturn(json_encode($resultList));
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('http://foo.bar.baz/v1/health/service/qux?passing')
+            ->willReturn($response);
+
+        $result = $this->consulApi->getServiceAddress('qux', '=1.0-0');
+        $this->assertEquals('alpha:42', $result);
+    }
+
+    public function testItShouldReturnARandomMatchingServiceIfThereAreMoreThanOneMatchingServices()
+    {
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $resultList = $this->getServiceListWithVersions();
+        $response->expects($this->once())->method('getBody')->willReturn(json_encode($resultList));
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('http://foo.bar.baz/v1/health/service/qux?passing')
+            ->willReturn($response);
+
+        $result = $this->consulApi->getServiceAddress('qux', '^2.0-0');
+        $this->assertThat(
+            $result,
+            $this->logicalOr($this->equalTo('beta:52'), $this->equalTo('gamma:62'))
+        );
     }
 
     public function testIfTheResponseIsNotJsonFalseShouldBeReturned()
@@ -66,5 +138,14 @@ class ConsulApiTest extends \PHPUnit_Framework_TestCase
         $response->expects($this->once())->method('getBody')->willReturn('orange-monkey');
         $this->httpClient->expects($this->once())->method('get')->willReturn($response);
         $this->assertFalse($this->consulApi->getServiceAddress('qux'));
+    }
+
+    private function getServiceListWithVersions()
+    {
+        return [
+            ['Service' => ['Address' => 'alpha', 'Port' => 42, 'Tags' => ['1-0-0']]],
+            ['Service' => ['Address' => 'beta', 'Port' => 52, 'Tags' => ['2.0.0']]],
+            ['Service' => ['Address' => 'gamma', 'Port' => 62, 'Tags' => ['3.1.0', '2-3-0']]]
+        ];
     }
 }


### PR DESCRIPTION
This PR adds semver filtering to the API client for Consul service discovery.

Note that the client will return a random service from all service instances that satisfy the semver constraint -- so a constraint like `^2.0.0` may return a service with version `2.1.0` the first time and `2.3.1` the second time. I think this is consistent with the sprit of semver's approach to breaking / non-breaking changes, but it is something to be aware of when choosing version constraints.