### PR TITLE
Revert "Add 'http://' protocol to request URL"

### DIFF
--- a/src/Consul/ConsulApi.php
+++ b/src/Consul/ConsulApi.php
@@ -27,7 +27,7 @@ class ConsulApi implements ServiceDiscoveryClientInterface
      */
     public function getServiceAddress($serviceName, $version = null)
     {
-        $url = "http://{$this->consulUri}/v1/health/service/$serviceName?passing";
+        $url = "{$this->consulUri}/v1/health/service/$serviceName?passing";
 
         $response = $this->httpClient->get($url);
 


### PR DESCRIPTION
Reverts CascadeEnergy/php-consul-client#5

This fix was too hasty -- I see what the original intent was here -- we should be changing the `consulUri` setting to include the protocol.
